### PR TITLE
Refactor date formatting utilities

### DIFF
--- a/src/features/table/CombinedDataTable.jsx
+++ b/src/features/table/CombinedDataTable.jsx
@@ -1,26 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import { useSelectionStore } from "@/shared/store";
+// Utility to format ISO date strings consistently across the app
+import { formatDateTime } from "@/shared/dateUtils";
 
-/**
- * 날짜 형식 변환 함수
- * 예: "2025. 6. 2. 10시 0분 0초" → "25/06/02 10:00"
- */
-function formatDateString(dateString) {
-  const match = dateString.match(
-    /(\d{4})\. (\d{1,2})\. (\d{1,2})\. (\d{1,2})시 (\d{1,2})분/
-  );
-  if (!match) return dateString;
-
-  const [, year, month, day, hour, minute] = match;
-  return `${year.slice(2)}/${month.padStart(2, "0")}/${day.padStart(
-    2,
-    "0"
-  )} ${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
-}
 
 /**
  * 통합 데이터 테이블 컴포넌트
- * @param {Object[]} data - 필터링된 로그 배열
+ * @param {Object[]} data - 필터링된 로그 배열.
+ *   각 항목은 { id, displayTimestamp, logType, info1, info2, duration } 형식을 가집니다.
  * @param {Object} typeFilters - 로그 타입 필터링 상태
  * @param {Function} handleFilter - 체크박스 변경 핸들러
  */
@@ -28,6 +15,7 @@ export default function CombinedDataTable({ data, typeFilters, handleFilter }) {
   const { selectedRow, source, setSelectedRow } = useSelectionStore();
   const rowRefs = useRef({});
 
+  // 타임라인에서 선택된 항목이 있을 때 해당 행이 보이도록 스크롤
   useEffect(() => {
     if (source === "timeline" && selectedRow && rowRefs.current[selectedRow]) {
       rowRefs.current[selectedRow].scrollIntoView({
@@ -105,7 +93,7 @@ export default function CombinedDataTable({ data, typeFilters, handleFilter }) {
                     {cols.map((c) => (
                       <td key={c.accessor} className="px-3 py-2">
                         {c.accessor === "displayTimestamp"
-                          ? formatDateString(row[c.accessor])
+                          ? formatDateTime(row[c.accessor])
                           : row[c.accessor] ?? "-"}
                       </td>
                     ))}

--- a/src/pages/TimelinePage.jsx
+++ b/src/pages/TimelinePage.jsx
@@ -5,6 +5,7 @@ import { TimelineBoard } from "@/features/timeline";
 import CombinedDataTable from "@/features/table/CombinedDataTable";
 import LogDetailSection from "@/features/table/LogDetailSection";
 import LoadingSpinner from "@/shared/LoadingSpinner";
+import { formatDateTime } from "@/shared/dateUtils";
 import { useSelectionStore } from "@/shared/store";
 
 const DATA_TYPES = {
@@ -44,18 +45,15 @@ export default function TimelinePage() {
     return logs
       .map((l) => ({
         id: l.id,
-        displayTimestamp: new Date(l.eventTime).toLocaleString("ko-KR", {
-          hour12: false,
-        }),
+        timestamp: new Date(l.eventTime).getTime(),
+        displayTimestamp: formatDateTime(l.eventTime),
         logType: l.logType,
         info1: l.eventType,
         info2: l.operator || "-",
         duration: l.duration?.toFixed(0) ?? "-",
       }))
       .filter((r) => typeFilters[r.logType])
-      .sort(
-        (a, b) => new Date(b.displayTimestamp) - new Date(a.displayTimestamp)
-      );
+      .sort((a, b) => b.timestamp - a.timestamp);
   }, [logs, logsLoading, enabled, typeFilters]);
 
   const { selectedRow } = useSelectionStore();

--- a/src/shared/dateUtils.js
+++ b/src/shared/dateUtils.js
@@ -1,0 +1,18 @@
+/**
+ * Format a Date (or date-like value) as 'YY/MM/DD HH:mm'.
+ * Returns the input unchanged if it cannot be parsed.
+ *
+ * @param {Date|string|number} date - value convertible to Date
+ * @returns {string} formatted date string
+ */
+export function formatDateTime(date) {
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return date;
+  const yy = String(d.getFullYear()).slice(-2);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yy}/${mm}/${dd} ${hh}:${mi}`;
+}
+


### PR DESCRIPTION
## Summary
- clean up date formatting with reusable `formatDateTime`
- simplify `CombinedDataTable` date handling
- use new util in `TimelinePage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6840018492648321af7a3afce2c3f4b0